### PR TITLE
RTC Status の type = data-channel の統計情報を Grafana ダッシュボードに追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@
 
 ## develop
 
+- [ADD] rtc-stats ダッシュボードに data-channel のグラフを追加する
+  - @tnamao
+- [FIX] `kohaku` ダッシュボードの from - to のタイムスタンプのミリ秒の扱いを変更する
+  - ミリ秒以下を from は切り捨て、to は切り上げする
+  - @tnamao
+
 ## 2023.1.1
 
 - [FIX] HTTP/2 Rapid Reset 対策として Go 1.21.3 以上でリリースバイナリを作成するよう修正する

--- a/grafana/dashboards/kohaku/kohaku.json
+++ b/grafana/dashboards/kohaku/kohaku.json
@@ -102,7 +102,7 @@
                   {
                     "targetBlank": true,
                     "title": "Connection's RTC Stats",
-                    "url": "d/bf887222-a2f7-4370-b688-b6c6b4ed47c0/rtc-stats?var-connection_id=${__value.raw}﻿﻿&from=﻿﻿${__data.fields.from_time}﻿﻿&to=﻿﻿${__data.fields.to_time}﻿﻿&var-channel_id=﻿${__data.fields.channel_id}﻿&var-session_id=${__data.fields.session_id}&var-DS_POSTGRESQL=﻿﻿${DS_POSTGRESQL}"
+                    "url": "d/bf887222-a2f7-4370-b688-b6c6b4ed47c0/rtc-stats?var-connection_id=${__value.raw}﻿﻿&from=﻿﻿${__data.fields.from_time}﻿﻿&to=﻿﻿${__data.fields.to_time}﻿﻿&var-channel_id=﻿${__data.fields.channel_id}﻿&var-session_id=${__data.fields.session_id}&var-DS_POSTGRESQL=﻿﻿PCC52D03280B7034C"
                   }
                 ]
               }
@@ -140,7 +140,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "WITH term AS (\n  SELECT\n    connection_id,\n    MAX(timestamp) AS last_time\n  FROM sora_user_agent_stats\n  WHERE $__timeFilter(timestamp)\n  GROUP BY connection_id\n)\n-- この接続一覧は Sora のコネクションを張ったタイミングでより新しいもの\nSELECT\n  timestamp AS created_timestamp,\n  channel_id,\n  session_id,\n  client_id,\n  connection_id,\n  role,\n  -- Data links に設定する from パラメータ用にミリ秒のタイムスタンプを生成\n  (EXTRACT(EPOCH FROM timestamp) :: bigint * 1000) :: bigint AS from_time,\n  -- Data links に設定する to パラメータ用にミリ秒のタイムスタンプを生成\n  (EXTRACT(EPOCH FROM term.last_time) :: bigint * 1000) :: bigint AS to_time\nFROM sora_connection\nLEFT OUTER JOIN term USING (connection_id)\nWHERE $__timeFilter(timestamp) \nORDER BY timestamp DESC\nOFFSET ${offset}\nLIMIT ${limit};",
+          "rawSql": "WITH term AS (\n  SELECT\n    connection_id,\n    MAX(timestamp) AS last_time\n  FROM sora_user_agent_stats\n  WHERE $__timeFilter(timestamp)\n  GROUP BY connection_id\n)\n-- この接続一覧は Sora のコネクションを張ったタイミングでより新しいもの\nSELECT\n  timestamp AS created_timestamp,\n  channel_id,\n  session_id,\n  client_id,\n  connection_id,\n  role,\n  -- Data links に設定する from パラメータ用にミリ秒のタイムスタンプを生成\n  (FLOOR(EXTRACT(EPOCH FROM timestamp)) :: bigint * 1000) :: bigint AS from_time,\n  -- Data links に設定する to パラメータ用にミリ秒のタイムスタンプを生成\n  (CEIL(EXTRACT(EPOCH FROM term.last_time)) :: bigint * 1000) :: bigint AS to_time\nFROM sora_connection\nLEFT OUTER JOIN term USING (connection_id)\nWHERE $__timeFilter(timestamp) \nORDER BY timestamp DESC\nOFFSET ${offset}\nLIMIT ${limit};",
           "refId": "A",
           "sql": {
             "columns": [
@@ -256,6 +256,6 @@
   "timezone": "",
   "title": "Kohaku",
   "uid": "fcec729e-f8a9-424b-b6e8-37b3697632c4",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/grafana/dashboards/kohaku/rtc-stats.json
+++ b/grafana/dashboards/kohaku/rtc-stats.json
@@ -2783,7 +2783,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "audio (${inbound_rtp_audio_rtc_stats_id})",
+      "title": "Audio (${inbound_rtp_audio_rtc_stats_id})",
       "type": "row"
     },
     {
@@ -2796,7 +2796,7 @@
       },
       "id": 3,
       "panels": [],
-      "title": "video (${inbound_rtp_video_rtc_stats_id})",
+      "title": "Video (${inbound_rtp_video_rtc_stats_id})",
       "type": "row"
     },
     {
@@ -6534,6 +6534,1054 @@
         }
       ],
       "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 68,
+      "panels": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "${DS_POSTGRESQL}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 67,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.1.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "${DS_POSTGRESQL}"
+              },
+              "editorMode": "code",
+              "format": "time_series",
+              "hide": false,
+              "rawQuery": true,
+              "rawSql": "SELECT\n  time_bucket_gapfill('$__interval', \"timestamp\") as time,\n  connection_id AS connection_id,\n  rtc_stats_id AS inbound_rtp_video_rtc_stats_id,\n  LOCF(LAST(((rtc_stats_data ->> 'dataChannelIdentifier') :: numeric), timestamp)) AS data_channel_identifier,\n  LOCF(LAST(((rtc_stats_data ->> 'messagesSent') :: numeric), timestamp)) AS messages_sent,\n  LOCF(LAST(((rtc_stats_data ->> 'bytesSent') :: numeric), timestamp)) AS bytes_sent,\n  LOCF(LAST(((rtc_stats_data ->> 'messagesReceived') :: numeric), timestamp)) AS messages_received,\n  LOCF(LAST(((rtc_stats_data ->> 'bytesReceived') :: numeric), timestamp)) AS bytes_received\nFROM\n  sora_user_agent_stats\nWHERE\n  $__timeFilter(timestamp)\n  AND connection_id IN (${connection_id:sqlstring})\n  AND rtc_stats_id IN (${data_channel_rtc_stats_id:sqlstring})\n  AND rtc_stats_type = 'data-channel'\nGROUP BY\n  time,\n  connection_id,\n  rtc_stats_id\nORDER BY\n  time\n;",
+              "refId": "A",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              },
+              "table": "sora_user_agent_stats"
+            },
+            {
+              "datasource": {
+                "type": "postgres",
+                "uid": "${DS_POSTGRESQL}"
+              },
+              "editorMode": "code",
+              "format": "time_series",
+              "hide": false,
+              "rawQuery": true,
+              "rawSql": "SELECT \n  a.time AS time,\n  a.connection_id AS connection_id,\n  a.data_channel_rtc_stats_id AS data_channel_rtc_stats_id,\n  ((a.messages_sent - lag(a.messages_sent, 1, NULL) OVER w) / $__interval_ms * 1000) :: numeric AS \"messagesSent/s\",\n  ((a.bytes_sent - lag(a.bytes_sent, 1, a.bytes_sent) OVER w) / $__interval_ms * 1000 * 8) :: numeric AS \"bytesSent_in_bits/s\",\n  ((a.messages_received - lag(a.messages_received, 1, NULL) OVER w) / $__interval_ms * 1000) :: numeric AS \"messagesReceived/s\",\n  ((a.bytes_received - lag(a.bytes_received, 1, a.bytes_received) OVER w) / $__interval_ms * 1000 * 8) :: numeric AS \"bytesReceived_in_bits/s\"\nFROM (\n  SELECT\n    time_bucket_gapfill('$__interval', \"timestamp\") as time,\n    connection_id AS connection_id,\n    rtc_stats_id AS data_channel_rtc_stats_id,\n  LOCF(LAST(((rtc_stats_data ->> 'messagesSent') :: numeric), timestamp)) AS messages_sent,\n  LOCF(LAST(((rtc_stats_data ->> 'bytesSent') :: numeric), timestamp)) AS bytes_sent,\n  LOCF(LAST(((rtc_stats_data ->> 'messagesReceived') :: numeric), timestamp)) AS messages_received,\n  LOCF(LAST(((rtc_stats_data ->> 'bytesReceived') :: numeric), timestamp)) AS bytes_received\n  FROM sora_user_agent_stats\n  WHERE\n    $__timeFilter(timestamp)\n    AND connection_id IN (${connection_id:sqlstring})\n    AND rtc_stats_id IN (${data_channel_rtc_stats_id:sqlstring})\n    AND rtc_stats_type = 'data-channel'\n  GROUP BY time, connection_id, data_channel_rtc_stats_id\n  ORDER BY time\n) AS a\nWINDOW w AS (PARTITION BY a.connection_id, a.data_channel_rtc_stats_id ORDER BY a.time)\nORDER BY time\n;",
+              "refId": "B",
+              "sql": {
+                "columns": [
+                  {
+                    "parameters": [],
+                    "type": "function"
+                  }
+                ],
+                "groupBy": [
+                  {
+                    "property": {
+                      "type": "string"
+                    },
+                    "type": "groupBy"
+                  }
+                ],
+                "limit": 50
+              }
+            }
+          ],
+          "title": "Data Channel Source Panel",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 4
+          },
+          "id": 69,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "dataChannelIdentifier",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(data_channel_identifier .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 4
+          },
+          "id": 70,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "messagesSent",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(messages_sent .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 4
+          },
+          "id": 74,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "messagesSent/s",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(messagesSent\\/s .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 12
+          },
+          "id": 71,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "bytesSent",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(bytes_sent .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 12
+          },
+          "id": 76,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "bytesSent_in_bits/s",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(bytesSent_in_bits\\/s .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 12
+          },
+          "id": 72,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "messagesReceived",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(messages_received .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 20
+          },
+          "id": 75,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "messagesReceived/s",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(messagesReceived\\/s .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 20
+          },
+          "id": 73,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "bytesReceived",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(bytes_received .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 20
+          },
+          "id": 77,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "datasource",
+                "uid": "-- Dashboard --"
+              },
+              "panelId": 67,
+              "refId": "A"
+            }
+          ],
+          "title": "bytesSent_in_bits/s",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "pattern": "^(bytesReceived_in_bits\\/s .+|Time)"
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "title": "Data Channel (${data_channel_rtc_stats_id})",
+      "type": "row"
     }
   ],
   "refresh": "",
@@ -6659,6 +7707,26 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "postgres",
+          "uid": "${DS_POSTGRESQL}"
+        },
+        "definition": "SELECT DISTINCT\n  concat(rtc_stats_id, ' ', rtc_stats_data->>'label') AS id\nFROM sora_user_agent_stats\nWHERE $__timeFilter(\"timestamp\")\n  AND connection_id IN (${connection_id:sqlstring})\n  AND rtc_stats_type = 'data-channel'\nORDER BY id;",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Data Channel RTC Stats ID",
+        "multi": true,
+        "name": "data_channel_rtc_stats_id",
+        "options": [],
+        "query": "SELECT DISTINCT\n  concat(rtc_stats_id, ' ', rtc_stats_data->>'label') AS id\nFROM sora_user_agent_stats\nWHERE $__timeFilter(\"timestamp\")\n  AND connection_id IN (${connection_id:sqlstring})\n  AND rtc_stats_type = 'data-channel'\nORDER BY id;",
+        "refresh": 1,
+        "regex": "/(?<text>^(?<value>[A-Za-z0-9]+) .*)/g",
+        "skipUrlSync": false,
+        "sort": 1,
         "type": "query"
       }
     ]


### PR DESCRIPTION
- `rtc-stats` ダッシュボードに `type = data-channel` のグラフを追加しました
- data channel の signaling などの統計情報は、`kohaku` ダッシュボードの from timestamp の扱い次第で拾うことができなかったため、 `kohaku` ダッシュボード内でミリ秒の扱いを明示的に切り上げ切り捨てするようにしました